### PR TITLE
Add dead-end helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,9 @@ To compute paths using more options than the game typically supports, see `pytho
 
 Finally, if you are not using the `twclient.py` (if not, why not? ;)) you can parse play logs after the fact with twparser.py - see `python3 twparser.py -h` for more information.
 
+### Enabling Manual Settings
+
+To enable auto-haggling:
+
+    sqlite3 tw2002.db "insert into settings (key, value) values('auto_haggle', '1')"
+


### PR DESCRIPTION
- Find explored presumed dead-end sectors.  ‘Presumed’ because of the potential for unexplored one-way warps into that sector.
- Document how to turn on auto_haggle